### PR TITLE
Solarshell for VS2017 updated with compiler toolset version 14.0

### DIFF
--- a/solarshell_VS2017.bat
+++ b/solarshell_VS2017.bat
@@ -1,9 +1,13 @@
 rem @echo off
 SET CURRENTDIR=%~dp0
+SET VCVERSION=%~1
+IF "%~1" EQU "" SET VCVERSION=14.1x
 rem call "C:\Program Files (x86)\Microsoft Visual C++ Build Tools\vcbuildtools.bat" amd64
 set VS150COMNTOOLS=C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\
 set VSVARPATH=%VS150COMNTOOLS:~0,-15%\VC\Auxiliary\Build
 set VSVERSION=msvc2017
-call "%VSVARPATH%\vcvarsall.bat" amd64 -vcvars_ver=14.0
+call "%VSVARPATH%\vcvarsall.bat" amd64 -vcvars_ver=%VCVERSION%
 cd "%CURRENTDIR%\.."
 "C:\Program Files\Git\git-bash.exe"
+
+


### PR DESCRIPTION
The solarshell for VS2017 has been updated with the compiler toolset version 14.0 that seems to be the required one to build the framework with the  "fromscratch.sh" script.