### PR TITLE
Solarshell script VS2017 with compiler toolset as a parameter

### DIFF
--- a/solarshell_VS2017.bat
+++ b/solarshell_VS2017.bat
@@ -1,13 +1,10 @@
 rem @echo off
 SET CURRENTDIR=%~dp0
 SET VCVERSION=%~1
-IF "%~1" EQU "" SET VCVERSION=14.1x
 rem call "C:\Program Files (x86)\Microsoft Visual C++ Build Tools\vcbuildtools.bat" amd64
 set VS150COMNTOOLS=C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\
 set VSVARPATH=%VS150COMNTOOLS:~0,-15%\VC\Auxiliary\Build
 set VSVERSION=msvc2017
-call "%VSVARPATH%\vcvarsall.bat" amd64 -vcvars_ver=%VCVERSION%
+IF "%~1" EQU "" (call "%VSVARPATH%\vcvarsall.bat" amd64) else (call "%VSVARPATH%\vcvarsall.bat" amd64 -vcvars_ver=%VCVERSION%)
 cd "%CURRENTDIR%\.."
 "C:\Program Files\Git\git-bash.exe"
-
-


### PR DESCRIPTION
Solarshell for VS2017 updated with compiler toolset version as a parameter (default is the latest 14.1x)